### PR TITLE
Send ether with .call to support smart contract takers

### DIFF
--- a/contracts/TestSmartContractWallet.sol
+++ b/contracts/TestSmartContractWallet.sol
@@ -1,0 +1,57 @@
+/*
+  << TestSmartContractWallet >>
+*/
+
+pragma solidity 0.7.5;
+
+import "openzeppelin-solidity/contracts/token/ERC721/ERC721.sol";
+
+contract ExchangeInterface{
+    function approveOrder_(address registry, address maker, address staticTarget, bytes4 staticSelector, bytes calldata staticExtradata, uint maximumFill, uint listingTime, uint expirationTime, uint salt, bool orderbookInclusionDesired)
+    external{}
+}
+contract ProxyInterface{
+    function registerProxy()
+    external{}
+}
+
+/**
+ * @title TestSmartContractWallet
+ * @dev Test contract for Smart contract wallets, proxies some calls an EOA wallet would make to setup on wyvern.
+ */
+contract TestSmartContractWallet {
+
+    event Deposit(address indexed _from, uint indexed _id, uint _value);
+
+    constructor () public {
+    }
+
+    // Called by atomicMatch when this contract is taker for an order with eth value exchanged.
+    receive() external payable {
+        // Use more than 2300 gas to test gas limit for send and transfer
+        emit Deposit(msg.sender, 0, msg.value);
+        emit Deposit(msg.sender, 1, msg.value);
+        emit Deposit(msg.sender, 2, msg.value);
+    }
+
+    // Proxy to exchange
+    function approveOrder_(address exchange, address registry, address maker, address staticTarget, bytes4 staticSelector, bytes calldata staticExtradata, uint maximumFill, uint listingTime, uint expirationTime, uint salt, bool orderbookInclusionDesired)
+    public returns (bool) {
+        ExchangeInterface(exchange).approveOrder_(registry, maker, staticTarget, staticSelector, staticExtradata, maximumFill, listingTime, expirationTime, salt, orderbookInclusionDesired);
+        return true;
+    }
+
+    // Proxy to registry
+    function registerProxy(address registry)
+    public returns (bool) {
+        ProxyInterface(registry).registerProxy();
+        return true;
+    }
+
+    // Proxy to erc721
+    function setApprovalForAll(address registry, address erc721, bool approved)
+    public returns (bool) {
+        ERC721(erc721).setApprovalForAll(registry, approved);
+        return true;
+    }
+}

--- a/contracts/exchange/ExchangeCore.sol
+++ b/contracts/exchange/ExchangeCore.sol
@@ -338,7 +338,9 @@ contract ExchangeCore is ReentrancyGuarded, StaticCaller, EIP712 {
         /* Transfer any msg.value.
            This is the first "asymmetric" part of order matching: if an order requires Ether, it must be the first order. */
         if (msg.value > 0) {
-            address(uint160(firstOrder.maker)).transfer(msg.value);
+            /* Reentrancy prevented by reentrancyGuard modifier */
+            (bool success,) = address(uint160(firstOrder.maker)).call{value: msg.value}("");
+            require(success, "native token transfer failed.");
         }
 
         /* Execute first call, assert success.

--- a/migrations/2_misc.js
+++ b/migrations/2_misc.js
@@ -6,6 +6,7 @@ const StaticMarket = artifacts.require('./StaticMarket.sol')
 const TestERC20 = artifacts.require('./TestERC20.sol')
 const TestERC721 = artifacts.require('./TestERC721.sol')
 const TestERC1271 = artifacts.require('./TestERC1271.sol')
+const TestSmartContractWallet = artifacts.require('./TestSmartContractWallet.sol')
 const TestAuthenticatedProxy = artifacts.require('./TestAuthenticatedProxy.sol')
 
 const { setConfig } = require('./config.js')
@@ -28,12 +29,14 @@ module.exports = async (deployer, network) => {
   await deployer.deploy(TestERC721)
   await deployer.deploy(TestAuthenticatedProxy)
   await deployer.deploy(TestERC1271)
+  await deployer.deploy(TestSmartContractWallet)
 
   if (network !== 'development') {
     setConfig('deployed.' + network + '.TestERC20', TestERC20.address)
     setConfig('deployed.' + network + '.TestERC721', TestERC721.address)
     setConfig('deployed.' + network + '.TestAuthenticatedProxy', TestAuthenticatedProxy.address)
     setConfig('deployed.' + network + '.TestERC1271', TestERC1271.address)
+    setConfig('deployed.' + network + '.TestSmartContractWallet', TestSmartContractWallet.address)
   }
 }
 


### PR DESCRIPTION
This PR is coauthored by @mikheevm / mikhail.mikheev@gnosis.pm from Gnosis and myself stewart@prysm.xyz from prysm.xyz.

Currently some smart contract wallets cannot sell on Wyvern in exchange for a native token because wyvern uses `.transfer()` which forwards a fixed amount of gas to the address. If the address is a smart contract, and if the receiver function uses more than `2300` gas, then the entire transaction will fail due to out of gas. In the case of Gnosis Safe, the `receive()` function emits an event when it receives a native token which causes the the transfer() call to run out of gas.

Example transaction: 
https://rinkeby.etherscan.io/tx/0xb03546168d6422c52000d41b5f791581f9dea6513ef4b42a84e5f9a8fe8256ce#internal

More info on this topic: https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/

The fix is to switch out the `transfer()` call with `.call{value:..}`. This opens the function to reentry attack, however `atomicMatch()` already has the `reentrancyGuard` modifier to prevent this.

I also added a test which verifies a smart contract can receive ether as the taker of an atomicMatch call despite using more than the 2300 fixed gas allotment given by transfer.


